### PR TITLE
Fix syntax highlighting

### DIFF
--- a/java/repository/src/main/java/com/bluejay/repository/util/IntStack.java
+++ b/java/repository/src/main/java/com/bluejay/repository/util/IntStack.java
@@ -1,6 +1,6 @@
 package com.bluejay.repository.util;
 
-public class IntStack {
+public final class IntStack {
     private final int[] mArray;
     private int mSize;
 
@@ -10,6 +10,10 @@ public class IntStack {
 
     public boolean isEmpty() {
         return mSize == 0;
+    }
+
+    public int peek() {
+        return mArray[mSize - 1];
     }
 
     public int pop() {

--- a/java/repository/src/main/java/thirdparty/android/text/CustomSpannableStringBuilder.java
+++ b/java/repository/src/main/java/thirdparty/android/text/CustomSpannableStringBuilder.java
@@ -1543,8 +1543,8 @@ public class CustomSpannableStringBuilder implements CharSequence, GetChars, Spa
                     // Leaf tree node (visit it and pop)
                     if (i < n) {
                         max = Math.max(max, mSpanEnds[i]);
-                        mSpanMax[i] = max;
                     }
+                    mSpanMax[i] = max;
                     stack.pop();
                 }
             } else if (previous == leftChild(i)) {
@@ -1554,8 +1554,8 @@ public class CustomSpannableStringBuilder implements CharSequence, GetChars, Spa
                 // We ascended the tree from the right. Visit the node and pop.
                 if (i < n) {
                     max = Math.max(max, mSpanEnds[i]);
-                    mSpanMax[i] = max;
                 }
+                mSpanMax[i] = max;
                 stack.pop();
             }
 


### PR DESCRIPTION
The problem was that we weren't unconditionally assigning to `mSpanMax[i]` like the old algorithm did. I also realized that both the inorder/postorder visitation algorithms are currently incorrect since they aggregate the max too much, e.g. for

```
    3
  1   4
 0 2 5 6
```

`mSpanMax[5]` will be assigned `max(0, 2, 1, 5)` although it should just be assigned `max(5)`. Still, more correct than the inorder implementation and neither seems to have observable side effects.